### PR TITLE
FIX ERROR: The SDK Build Tools revision (24.0.3) is too low for proje…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 2
         versionName "1.1"
         ndk {


### PR DESCRIPTION
…ct ':react-native-imei'. Minimum required is 25.0.0


FIX ERROR: The SDK Build Tools revision (24.0.3) is too low for project ':react-native-imei'. Minimum required is 25.0.0

The error happens to me with REACT NATIVE 56.

To fixed i just change the build.gradle.