### PR TITLE
chore(gradle) : replace deprecated keyword

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -19,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    api 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
- Omit `buildToolsVersion ` to avoid warning on build logs
- Update dependencies `compile` to use new `api` token to match [Link](http://d.android.com/r/tools/update-dependency-configurations.html)